### PR TITLE
add export command to build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "preview": "vite preview",
     "lint": "eslint \"src/**/*.ts\" --fix",
     "start:devnet": "VITE_APP_ENVIRONMENT=devnet vite",
-    "build:devnet": "VITE_APP_ENVIRONMENT=testnet && tsc && vite build",
+    "build:devnet": "export VITE_APP_ENVIRONMENT=testnet && tsc && vite build",
     "start:testnet": "VITE_APP_ENVIRONMENT=testnet vite",
-    "build:testnet": "VITE_APP_ENVIRONMENT=testnet && tsc && vite build",
+    "build:testnet": "export VITE_APP_ENVIRONMENT=testnet && tsc && vite build",
     "start:mainnet": "VITE_APP_ENVIRONMENT=mainnet vite",
-    "build:mainnet": "VITE_APP_ENVIRONMENT=mainnet && tsc && vite build"
+    "build:mainnet": "export VITE_APP_ENVIRONMENT=mainnet && tsc && vite build"
   },
   "dependencies": {
     "@helia/strings": "^1.0.0",


### PR DESCRIPTION
When i builded project and deployed it on netlify VITE_APP_ENVIRONMENT was undefined. Therefore i added export command into build script to ensure that the VITE_APP_ENVIRONMENT variable is set in the environment for the entire session. This makes the variable available to the TypeScript compiler and the Vite build command. 